### PR TITLE
Add docker-based dev environment, fix api not restarting on crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,43 @@
 # Concatenate Videos
 
+
+## Development
+
+This application is designed to be developed locally using docker compose.
+
+### Prerequisites
+
+- Docker (e.g. [Docker Desktop][])
+- Docker Compose (included with Docker Desktop)
+
 ### Running the application
 
-OS-level Dependencies:
-
-```
-brew install ffmpeg
-```
-
-Start the api and background job processor
-
-```
-npm start
+```sh
+# Starts both the api and the background job processor in the background
+npm run dev:start
 ```
 
-api runs on port 8000
+### Accessing the application
+
+The API runs on port 8000, and can be accessed locally at `http://localhost:8000`
+
+### Viewing logs
+
+```sh
+# Tails the logs in real time
+npm run dev:logs
+```
+
+### Stopping the application
+
+```sh
+# Stops the api and the background job processor, and removes the containers
+npm run dev:stop
+```
+
+## Architecture
+
+![Overview](./architecture-overview.png)
 
 ### API Call Flow
 
@@ -49,6 +72,8 @@ returns
 }
 ```
 
-### Architecture
 
-![Overview](./architecture-overview.png)
+
+<!-- Links -->
+
+[Docker Desktop]: https://www.docker.com/products/docker-desktop/

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,19 @@
+# Use an LTS image to ensure long term support for security updates
+# (critical since image and video processing has a long history of
+# security issues)
+
+FROM ubuntu:24.04
+
+# Install ffmpeg, node, and npm
+RUN apt-get update \
+ && apt-get install -y ffmpeg nodejs npm \
+ && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory for subsequent commands
+WORKDIR /app
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# On start, install dependencies and run the app
+CMD [ "bash", "-c", "npm install && npm start" ]

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  api:
+    build:
+      context: ..
+      dockerfile: dev/Dockerfile
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    volumes:
+      - ..:/app
+    environment:
+      - NODE_ENV=development

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "A service for concatenating videos",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon ./src/index.ts",
-    "build": "tsc"
+    "start": "nodemon --exitcrash ./src/index.ts",
+    "build": "tsc",
+    "dev:start": "cd dev && docker compose up --build --detach",
+    "dev:stop": "cd dev && docker compose down",
+    "dev:restart": "npm run dev:stop && npm run dev:start",
+    "dev:logs": "cd dev && docker compose logs --follow"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This intends to resolve concerns over differing ffmpeg versions in use between development and production