### PR TITLE
Convert prod from EC2 to ECS

### DIFF
--- a/prod/.dockerignore
+++ b/prod/.dockerignore
@@ -1,0 +1,18 @@
+# git
+.git
+.gitignore
+
+# jlong uses mercurial, so we need to ignore these files
+.hg
+
+# node_modules
+node_modules
+
+# dev docker configuration
+dev
+
+# prod docker configuration
+prod
+
+# build output
+dist

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -1,0 +1,68 @@
+# Use an LTS image to ensure long term support for security updates
+# (critical since image and video processing has a long history of
+# security issues)
+
+FROM ubuntu:24.04 AS builder
+
+RUN apt-get update \
+ && apt-get install -y curl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+
+RUN apt-get update \
+ && apt-get install -y ffmpeg nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory for subsequent commands
+WORKDIR /app
+
+# Copy the package.json and package-lock.json files
+#
+# This is being done to take advantage of Docker's build cache, where
+# the `npm install` command will only be re-run if the package.json or
+# package-lock.json files have changed.
+
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Prune the dev dependencies
+RUN npm prune --production
+
+# NPM install may necessitate pulling in a lot of dependencies, so we'll
+# use a second stage to install only the dependencies needed to run the
+# app.
+FROM ubuntu:24.04
+
+RUN apt-get update \
+ && apt-get install -y curl \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+
+RUN apt-get update \
+ && apt-get install -y ffmpeg nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy the rest of the application code
+COPY . /app
+
+COPY --from=builder /app/node_modules /app
+COPY --from=builder /app/dist /app/dist
+
+# Expose the port the app runs on
+EXPOSE 8000
+
+# Set the working directory for subsequent commands
+WORKDIR /app
+
+# On start, run the app
+CMD [ "node", "dist/index.js" ]

--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  api:
+    build:
+      context: ..
+      dockerfile: prod/Dockerfile
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      - NODE_ENV=production


### PR DESCRIPTION
## Why?

Based off the identified issues, and the maximum number of pending jobs at peak load, it seems this application would benefit from moving the job processor to dynamically-provisioned compute like ECS Fargate or EKS Fargate. SQS could be a candidate to handle queuing jobs, with Dynamo to handle tracking job statuses.

## Status

An initial docker image was created to resemble the current production environment, but may not be optimal if the job processor is to be separated from the API.

Paused, while other priorities are tackled.
